### PR TITLE
Version for beta deployment v3

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,6 +25,7 @@ platform :android do
 
 	lane :beta do
 		bump_version_code
+		update_version_name
 		gradle(
 			task: 'clean assemble',
 			build_type: 'Release',


### PR DESCRIPTION
Get version for latest Github release and use as a version for beta releases (internal track).
Requires that there is always a drafted release for the next production release.
Add call to update_version_name in beta lane. 